### PR TITLE
fix: update CI pipeline to make the build pass

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -19,6 +19,7 @@ GitHub
 Grafana
 IAM
 installable
+integrations
 JSON
 Juju
 Kubeflow
@@ -46,6 +47,7 @@ reST
 reStructuredText
 roadmap
 RTD
+snapcraft
 subdirectories
 subfolders
 subtree

--- a/docs/Makefile.sp
+++ b/docs/Makefile.sp
@@ -7,7 +7,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXDIR     = .sphinx
-SPHINXOPTS    ?= -c . -d $(SPHINXDIR)/.doctrees -j auto
+SPHINXOPTS    ?= -c . -d $(SPHINXDIR)/.doctrees
 SPHINXBUILD   ?= $(VENVDIR)/bin/sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,6 +154,8 @@ linkcheck_anchors_ignore_for_url = [
     r'https://github\.com/.*'
 ]
 
+linkcheck_retries = 3
+
 ############################################################
 ### Additions to default configuration
 ############################################################

--- a/docs/howto/rust-setup.md
+++ b/docs/howto/rust-setup.md
@@ -25,7 +25,7 @@ Install the `cargo` package, which automatically pulls required dependencies, in
 
 ### Installing latest Rust toolchain using Rustup
 
-Install the Rustup manager from the Snap Store [snaprcraft.io: Rustup](https://snapcraft.io/rustup) and the Rust toolchain using `rustup`.
+Install the Rustup manager from the Snap Store [snapcraft.io: Rustup](https://snapcraft.io/rustup) and the Rust toolchain using `rustup`.
 
 1. In a terminal, run:
 


### PR DESCRIPTION
- canonical-sphinx does not declare parallel capability. Drop -j as it creates a warning and causing the pipeline to fail.

See: https://github.com/canonical/canonical-sphinx/issues/27

This caused Rust guide to have a typo/miss some updates to the wordlist.

- linkcheck (skipped due to previous failure) did not retry, causing a build failure

