### PR TITLE
doc: fix duplicate link name

### DIFF
--- a/docs/howto/java-use.md
+++ b/docs/howto/java-use.md
@@ -7,7 +7,7 @@ This article provides basic guidance on how to use of the Java toolchain for dev
 To use {command}`javac` directly, refer to the example {ref}`compiling-java-application-using-javac-directly`.
 
 
-(installing-java-development-kit)=
+(installing-java-development-kit-dev)=
 ## Installing Java Development Kit
 
 To install the default Java Development Kit for your Ubuntu release, run:
@@ -33,7 +33,7 @@ Setting up and building a new Java project using the Apache Maven tool.
 ### Prerequisites
 :::
 
-- Java Development Kit; refer to {ref}`installing-java-development-kit`.
+- Java Development Kit; refer to {ref}`installing-java-development-kit-dev`.
 
 - Apache Maven:
 
@@ -173,7 +173,7 @@ Setting up and building a new Java project using the Gradle build tool.
 ### Prerequisites
 :::
 
-- Java Development Kit; refer to {ref}`installing-java-development-kit`.
+- Java Development Kit; refer to {ref}`installing-java-development-kit-dev`.
 
 - Gradle:
 
@@ -325,7 +325,7 @@ Compiling a Java application directly using the {command}`javac` tool.
 ### Prerequisites
 :::
 
-- Java Development Kit; refer to {ref}`installing-java-development-kit`.
+- Java Development Kit; refer to {ref}`installing-java-development-kit-dev`.
 
 
 :::
@@ -372,7 +372,7 @@ Running a Java application as a script with the {command}`java` interpreter spec
 ### Prerequisites
 :::
 
-- Java Development Kit; refer to {ref}`installing-java-development-kit`.
+- Java Development Kit; refer to {ref}`installing-java-development-kit-dev`.
 
 
 :::


### PR DESCRIPTION
This fixes duplicate link name `installing-java-development-kit` present in both `java-use` and `java-setup` howtos. 
