### PR TITLE
fix ASP.NET runtime snap install instruction

### DIFF
--- a/docs/howto/dotnet-setup.md
+++ b/docs/howto/dotnet-setup.md
@@ -212,7 +212,7 @@ Examples:
 
 - To install the runtime of the latest .NET release, run:
   ```text
-  dotnet-installer install dotnet-runtime latest
+  dotnet-installer install runtime latest
   ```
 - To install the SDK of the latest .NET LTS release, run:
   ```text


### PR DESCRIPTION
The example for installing the ASP.NET runtime snap results in an error when executed, because the value for the "component" to install is invalid.

See an example of what happens when following the current instructions:
```
root@noble:~# dotnet-installer install dotnet-runtime latest
[ERR] The requested component dotnet-runtime latest does not exist.
```