### PR TITLE
Use user-friendly `apt` instead of apt-get

### DIFF
--- a/docs/howto/rust-setup.md
+++ b/docs/howto/rust-setup.md
@@ -19,7 +19,7 @@ Install the {pkg}`cargo` package, which automatically pulls required dependencie
 1. In a terminal, run:
 
     ```none
-    sudo apt-get install cargo
+    sudo apt install cargo
     ```
 
 
@@ -51,7 +51,7 @@ Many external Rust libraries on [crates.io](https://crates.io) contain C/C++ cod
 Use the following command to install them:
 
 ```none
-sudo apt-get install build-essential
+sudo apt install build-essential
 ```
 :::
 
@@ -91,7 +91,7 @@ Some targets on that list require installing additional packages or downloading 
 1. To target Windows, install the following packages:
 
     ```none
-    sudo apt-get install binutils-mingw-w64 g++-mingw-w64 gcc-mingw-w64
+    sudo apt install binutils-mingw-w64 g++-mingw-w64 gcc-mingw-w64
     ```
 
 2. Add the Windows target to the toolchain:
@@ -114,7 +114,7 @@ Many Rust applications can run inside a web browser. To build a Rust project for
 1. Install the required packages:
 
     ```none
-    sudo apt-get install clang lld
+    sudo apt install clang lld
     ```
 
 2. Add the `wasm` target to the toolchain:
@@ -137,7 +137,7 @@ Your code editor or IDE probably already has debugging functionalities tailored 
 To install the corresponding debugging support packages, run:
 
 ```none
-sudo apt-get install gdb lldb rust-gdb rust-lldb
+sudo apt install gdb lldb rust-gdb rust-lldb
 ```
 
 You can then use {command}`gdb` or {command}`lldb` to debug your Rust applications.


### PR DESCRIPTION
Use user-friendly `apt` instead of `apt-get` in the developer guide.