### PR TITLE
Fix required rust-gdb and rust-lldb packages

### DIFF
--- a/docs/howto/rust-setup.md
+++ b/docs/howto/rust-setup.md
@@ -136,7 +136,7 @@ Many Rust applications can run inside a web browser. To build a Rust project for
 Your code editor or IDE probably already has debugging functionalities tailored for Rust applications. If not, you can also debug Rust applications on Ubuntu using familiar debugging tools such as [GDB](https://www.gnu.org/software/gdb/) and [LLDB](https://lldb.llvm.org/).
 
 :::{attention}
-The {pkg}`cargo` package conflicts with the {command}`rust-lldb` command. To use {command}`rust-lldb`, the Rustup snap should be installed as described [above](#rustup-install). Then, {pkg}`lldb` should be installed normally as described below.
+The {pkg}`cargo` package conflicts with the {command}`rust-lldb` command. To use {command}`rust-lldb`, install the Rustup snap as described in {ref}`rustup-install. Then install {pkg}`lldb` normally as described below.
 :::
 
 To install the corresponding debugging support packages, run:


### PR DESCRIPTION
This PR fixes #28 by amending the packages required to use the `rust-lldb` and `rust-gdb` scripts.

The Rustup snap provides the `rust-lldb` and `rust-gdb` scripts; since they are just wrapper scripts around `lldb` and `gdb` respectively, they naturally _just_ need the `lldb` and `gdb` packages.

However, trying to use `rust-lldb` causes conflicts if `cargo` also happens to be installed at the same time; I added a message before the installation script alerting the reader of this incompatibility.

On fresh Plucky and Noble VMs I followed the steps: I _just_ installed the Rustup snap (and not `cargo`), installed the stable toolchain, then installed `lldb` and `gdb`. I ran both `rust-lldb` and `rust-gdb` and both worked.