### PR TITLE
Add a help box if the reader has no linker

### DIFF
--- a/docs/howto/rust-setup.md
+++ b/docs/howto/rust-setup.md
@@ -23,6 +23,7 @@ Install the {pkg}`cargo` package, which automatically pulls required dependencie
     ```
 
 
+(rustup-install)=
 ### Installing the latest Rust toolchain using Rustup
 
 Install the Rustup manager from the Snap Store [snapcraft.io: Rustup](https://snapcraft.io/rustup) and the Rust toolchain using {command}`rustup`.
@@ -134,10 +135,15 @@ Many Rust applications can run inside a web browser. To build a Rust project for
 
 Your code editor or IDE probably already has debugging functionalities tailored for Rust applications. If not, you can also debug Rust applications on Ubuntu using familiar debugging tools such as [GDB](https://www.gnu.org/software/gdb/) and [LLDB](https://lldb.llvm.org/).
 
+:::{attention}
+The {pkg}`cargo` package conflicts with the {command}`rust-lldb` command. To use {command}`rust-lldb`, the Rustup snap should be installed as described [above](#rustup-install). Then, {pkg}`lldb` should be installed normally as described below.
+:::
+
 To install the corresponding debugging support packages, run:
 
 ```none
-sudo apt-get install gdb lldb rust-gdb rust-lldb
+sudo apt-get install gdb lldb
 ```
 
-You can then use {command}`gdb` or {command}`lldb` to debug your Rust applications.
+You can then use {command}`rust-gdb` or {command}`rust-lldb` to debug your Rust applications.
+

--- a/docs/howto/rust-use.md
+++ b/docs/howto/rust-use.md
@@ -40,6 +40,10 @@ If you want to use {command}`rustc` without {command}`cargo`, refer to the examp
     cargo run
     ```
 
+:::{attention}
+When building and running the program, if you get an error message related to a missing linker, then you are missing some essential build tools. They can be installed with `sudo apt install build-essential`.
+:::
+
 
 ## Building programs with nightly Rust
 


### PR DESCRIPTION
Currently, in the `rust-setup` part of the guide, the instruction to install `build-essential` is merely a suggestion within an info box:

https://github.com/canonical/ubuntu-for-developers-docs/blob/5400746e8419930d700b76d65683642ab85c58ee/docs/howto/rust-setup.md?plain=1#L48-L56

However, when starting from a completely fresh Plucky VM and installing only the "necessary" requirements, the "Hello world" example in `rust-use` fails with the message `error: linker \`cc\` not found`.

Just in case the reader didn't install `build-essential` earlier, I added a little info box to help them out.