### PR TITLE
fix: incorrect command line instructions

### DIFF
--- a/docs/howto/dotnet-setup.md
+++ b/docs/howto/dotnet-setup.md
@@ -217,7 +217,7 @@ Examples:
   ```
 - To install the SDK of the latest .NET LTS release, run:
   ```text
-  dotnet-installer remove sdk lts
+  dotnet-installer install sdk lts
   ```
 - To install the .NET 8 ASP\.NET Core runtime, run:
   ```text


### PR DESCRIPTION
The documentation explains that one of the provided command line examples installs a .NET component while actually removing it. This commit fixes the used verb in the incorrect command line instruction.