### PR TITLE
style: no text transform text literals in table headers

### DIFF
--- a/docs/.sphinx/_static/custom_header.css
+++ b/docs/.sphinx/_static/custom_header.css
@@ -1,2 +1,3 @@
 .p-logo-text { width: 22em; }
 .nav-more-links { width: 12em!important; }
+th .pre, th code { text-transform: none; }


### PR DESCRIPTION
The text of literals (using the <code>&#96;&#96;</code> syntax) should not be transformed
to uppercase in table headers by default, because the casing can matter
if literals are used.