### PR TITLE
Fix conf.py problem causing local previews to fail

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,7 +187,7 @@ extensions = [
     "sphinx_last_updated_by_git",
     "sphinx.ext.intersphinx",
     "sphinxcontrib.mermaid",
-    "sphinx-prompt",
+    "sphinx_prompt",
     "sphinx.ext.extlinks",
     "sphinx_sitemap",
 ]


### PR DESCRIPTION
## Bug Description

When running `make run` to locally preview changes, the process fails with the following message:

```
Extension error:
Could not import extension sphinx-prompt (exception: No module named 'sphinx-prompt')
Sphinx exited with exit code: 2
The server will continue serving the build folder, but the contents being served are no longer in sync with the documentation sources. Please fix the cause of the error above or press Ctrl+C to stop the server.
[sphinx-autobuild] Serving on http://127.0.0.1:8000
[sphinx-autobuild] Waiting to detect changes...
```

This failure is caused by the use of `sphinx-autobuild` (with a hyphen) within the extensions list of `conf.py`:
https://github.com/canonical/ubuntu-for-developers-docs/blob/0afe43d8be569a9a3eb93184b114a1ffc8089b6c/docs/conf.py#L184-L193

As stated by `sphinx-autobuild`'s [own documentation](https://pypi.org/project/sphinx-prompt/), this extension must be imported as `sphinx_autobuild` (with an underscore) instead.

## Steps to Reproduce

In a fresh Ubuntu 24.04 LXD container:

```shell
sudo apt update
sudo apt upgrade -y
sudo apt install -y make python3-venv
git clone https://github.com/canonical/ubuntu-for-developers-docs
cd ubuntu-for-developers-docs/docs
make run
```

After that, switch to my proposed branch and see that things now work as intended:

```shell
git remote add maxgmr https://github.com/maxgmr/ubuntu-for-developers-docs
git fetch maxgmr
git checkout -b fix-sphinx-prompt-import maxgmr/fix-sphinx-prompt-import
make run
```