### PR TITLE
Update Rust toolchain availability page for 25.10

### DIFF
--- a/docs/reference/availability/rust.md
+++ b/docs/reference/availability/rust.md
@@ -17,7 +17,7 @@ See the [user guide for rustup](https://rust-lang.github.io/rustup/concepts/chan
 
 | Ubuntu version | available Rust versions | {lpsrc}`rust-defaults` version | 
 | --- | --- | --- |
-| 25.10 (Questing Quokka)     | 1.81, 1.82, 1.83, 1.84, **1.85** | 1.85 |
+| 25.10 (Questing Quokka)     | **1.85**, 1.88 | 1.85 |
 | 25.04 (Plucky Puffin)       | 1.81, 1.82, 1.83, **1.84** | 1.84 |
 | 24.10 (Oracular Oriole)     | 1.74, **1.80**, 1.81, 1.82 | 1.80 |
 | 24.04 LTS (Noble Numbat)    | 1.74, **1.75**, 1.76, 1.77, 1.78, 1.79, 1.80, 1.81, 1.82 | - |
@@ -32,6 +32,7 @@ See the [user guide for rustup](https://rust-lang.github.io/rustup/concepts/chan
 
 | Rust version | Source package | 
 |--------------|----------------|
+| 1.88 | {lpsrc}`rustc-1.88` |
 | 1.85 | {lpsrc}`rustc-1.85` |
 | 1.84 | {lpsrc}`rustc-1.84` |
 | 1.83 | {lpsrc}`rustc-1.83` |


### PR DESCRIPTION
[`rustc-1.88`](https://pad.lv/u/rustc-1.88) shall be the most recent Rust toolchain available in the 25.10 archive, while [`rust-defaults`](https://pad.lv/u/rust-defaults) shall point to [`rustc-1.85`](https://pad.lv/u/rustc-1.85). All other toolchains were unused by the kernel team and the archive, so they were removed.

I have updated the Rust toolchain availability page to reflect the addition of `rustc-1.88` and the removal of older toolchains. This shall be the final update to the Rust toolchain availability page for 25.10.