### PR TITLE
Develop with python ubuntu review

### DIFF
--- a/docs/tutorials/python-use.md
+++ b/docs/tutorials/python-use.md
@@ -41,7 +41,7 @@ To separate the system installation of Python from your development and testing 
     ```
 
 ::::{note}
-If you attempt to install a Python package using `pip` outside of a Python virtual environment, such as `venv`, on an Ubuntu (Debian) system, you will receive a warning that explains that you should keep the system installation of Python (installed using `.deb` packages from Ubuntu repositories) separate from Python packages installed using `pip`:
+If you attempt to install a Python package using `pip` outside of a Python virtual environment, such as `venv`, on an Ubuntu (Debian) system, you receive a warning that explains that you should keep the system installation of Python (installed using `.deb` packages from Ubuntu repositories) separate from Python packages installed using `pip`:
 
 :::{raw} html
 <div class="highlight-default notranslate"><div class="highlight"><pre>


### PR DESCRIPTION
I have reviewed the [Python development guide](https://documentation.ubuntu.com/ubuntu-for-developers/tutorials/python-use/) as a part of the October 2025 Docs Focus Week.

## Changes

- In c1cf72a I prepended `$` to all example terminal commands. (Not sure if this is the recommended format!)
- There are some miscellaneous formatting/grammar nitpicks in 057c82a.
- In 0263d81 I highlighted the code block lines which were being changed in that particular step.
- 55e8464 makes the path name consistent by replacing `/home/rkratky` with `/home/dev`.
- 3f4cf7e makes the example code consistent with the formatted code the reader would have at that step.
- Finally, 078e089 makes the `pytest` demo instructions reproducible by ensuring the reader installs the right dependencies and comments out any debug lines which break the test.

I've confirmed that these docs work properly when following their instructions inside fresh Questing and Noble containers.