### PR TITLE
Remove Oracular and add Resolute to Rust toolchain availability page

### DIFF
--- a/docs/reference/availability/rust.md
+++ b/docs/reference/availability/rust.md
@@ -17,9 +17,9 @@ See the [user guide for rustup](https://rust-lang.github.io/rustup/concepts/chan
 
 | Ubuntu version | available Rust versions | {lpsrc}`rust-defaults` version | 
 | --- | --- | --- |
+| 26.04 LTS (Resolute Raccoon)| **1.88** | 1.88 |
 | 25.10 (Questing Quokka)     | **1.85**, 1.88 | 1.85 |
 | 25.04 (Plucky Puffin)       | 1.81, 1.82, 1.83, **1.84** | 1.84 |
-| 24.10 (Oracular Oriole)     | 1.74, **1.80**, 1.81, 1.82 | 1.80 |
 | 24.04 LTS (Noble Numbat)    | 1.74, **1.75**, 1.76, 1.77, 1.78, 1.79, 1.80, 1.81, 1.82 | - |
 | 22.04 LTS (Jammy Jellyfish) | 1.62, **1.75**, 1.76, 1.77, 1.78, 1.79, 1.80, 1.81, 1.82 | - |
 | 20.04 LTS (Focal Fossa)     | 1.75, 1.76, 1.77, 1.78, 1.79, 1.80, 1.82 | - |


### PR DESCRIPTION
I've updated the Rust toolchain availability page to reflect the fact that `rust-defaults` in Resolute is 1.88.

I've also removed the Oracular entry from the table, as it is now EoL.