### PR TITLE
fix: .NET 10 is now available in the archive for plucky and noble

### DIFF
--- a/docs/reference/availability/dotnet.md
+++ b/docs/reference/availability/dotnet.md
@@ -109,15 +109,14 @@ See: {ref}`dotnet-installation-snap`
 |-----------------------------|---------|---------|---------|-----------|
 | 26.04 (Resolute Raccoon)    | 8{dim}`¹`, 9, 10 | 8{dim}`¹`, 9, 10 | 8{dim}`¹`, 9, 10 | 8{dim}`¹`, 9, 10 |
 | 25.10 (Questing Quokka)     | **8**, 9, 10 | **8**, 9, 10 | **8**, 9, 10 | **8**, 9, 10 |
-| 25.04 (Plucky Puffin)       | **8**, 9, 10{dim}`³` | **8**, 9, 10{dim}`³` | **8**, 9, 10{dim}`³` | **8**, 9, 10{dim}`³` |
-| 24.04 LTS (Noble Numbat)    | 6{dim}`¹ ²`, 7{dim}`¹ ²`, **8**, 9{dim}`¹`, 10{dim}`³` | 6{dim}`¹ ²`, 7{dim}`¹ ²`, **8**, 9{dim}`¹`, 10{dim}`³` | **8**, 9{dim}`¹`, 10{dim}`³` | **8**, 9{dim}`¹`, 10{dim}`³` |
+| 25.04 (Plucky Puffin)       | **8**, 9, 10 | **8**, 9, 10 | **8**, 9, 10 | **8**, 9, 10 |
+| 24.04 LTS (Noble Numbat)    | 6{dim}`¹ ²`, 7{dim}`¹ ²`, **8**, 9{dim}`¹`, 10 | 6{dim}`¹ ²`, 7{dim}`¹ ²`, **8**, 9{dim}`¹`, 10 | **8**, 9{dim}`¹`, 10 | **8**, 9{dim}`¹`, 10 |
 | 22.04 LTS (Jammy Jellyfish) | **6**, 7, **8**, 9{dim}`¹`, 10{dim}`¹` | **6**, 7, **8**, 9{dim}`¹`, 10{dim}`¹` | **8**, 9{dim}`¹`, 10{dim}`¹` | **8**, 9{dim}`¹`, 10{dim}`¹` |
 
 <!-- Do not forget to add 4 spaces at the end of line to keep future diffs more readable -->
 **bold** -- package is in main    
 ¹ -- available in the {ref}`dotnet-backports-ppa` only    
 ² -- version is no longer maintained by Canonical (End of Life)    
-³ -- .NET 10 RC2 is available in the {ref}`dotnet-previews-ppa`. We are working on getting the final release in the Ubuntu package archive. In the meantime we recommend {ref}`dotnet-installation-snap`.    
 
 | .NET Version | Source package | End of Life (Upstream) | 
 |--------------|----------------|------------------------|


### PR DESCRIPTION
This PR removes the footnote that says

> ³ -- .NET 10 RC2 is available in the {ref}`dotnet-previews-ppa`. We are working on getting the final release in the Ubuntu package archive. In the meantime we recommend {ref}`dotnet-installation-snap`.

Since .NET 10 is now available in the noble and plucky archives.