### PR TITLE
Add Zig

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -41,3 +41,9 @@ VSCode
 WebStorm
 Xenial
 Xerus
+Zig
+ziglang
+ZLS
+zls
+libc
+musl

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,6 +153,7 @@ linkcheck_ignore = [
     r"https://www\.gnu\.org/.*",
     r"https://matrix\.to/.*",
     r"https://blog\.local-optimum\.net/.*",
+    r"https://www\.winehq\.org.*",
 ]
 
 # Pages on which to ignore anchors
@@ -229,7 +230,7 @@ llms_txt_description = (
     "Linux distribution as a development platform. The guides focus on "
     "setting up and using the Ubuntu system as a workstation for developers, "
     "with an emphasis on the following toolchains: Python, Golang, Rust, "
-    "GCC, Clang, .NET, and Java."
+    "GCC, Clang, .NET, Java, and Zig."
 )
 
 # markdown-builder config

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -19,6 +19,7 @@ Install and set up GCC <gcc-setup>
 Install and set up Clang <clang-setup>
 Install and set up .NET <dotnet-setup>
 Install and set up Java <java-setup>
+Install and set up Zig <zig-setup>
 :::
 
 Follow up with 'Hello, world!' {ref}`tutorials` for each of the toolchains.

--- a/docs/howto/zig-setup.md
+++ b/docs/howto/zig-setup.md
@@ -1,0 +1,113 @@
+---
+myst:
+  html_meta:
+    description: "Install Zig and set up a development environment on Ubuntu Desktop."
+---
+
+(install-zig)=
+# How to set up a development environment for Zig on Ubuntu
+
+This guide covers installing the Zig toolchain and setting up a development environment on Ubuntu. [Zig](https://ziglang.org/) is a general-purpose systems programming language designed for robustness, performance, and simplicity, with built-in cross-compilation support.
+
+
+## Installing Zig
+
+There are two main options for installing Zig on Ubuntu:
+
+* Using Ubuntu packages from the Ubuntu archive: Official packages maintained by the Ubuntu team and installed through the Ubuntu package-management system. Packages are available from **Ubuntu 25.10** onward. Use this method on a supported release to get a system-managed installation.
+
+* Using the [Zig snap](https://snapcraft.io/zig), a community-maintained snap package. Use this method if you need a recent Zig release on an older Ubuntu release, or want a version not yet available in the archive.
+
+
+### Installing Zig from Ubuntu packages
+
+Zig packages are available in the Ubuntu archive from Ubuntu 25.10 (Questing Quokka) onward.
+
+1. Install the {pkg}`zig` package:
+
+    ```{terminal}
+    :dir: ~
+    :user: dev
+    :host: ubuntu
+
+    sudo apt install zig
+    ```
+
+1. Verify the installation:
+
+    ```{terminal}
+    :dir: ~
+    :user: dev
+    :host: ubuntu
+
+    zig version
+    ```
+
+
+### Installing Zig from the snap
+
+The [Zig snap](https://snapcraft.io/zig) is a community-maintained package available for all Ubuntu releases. The `latest/beta` channel tracks Zig stable releases.
+
+1. Install the snap from the `latest/beta` channel:
+
+    ```{terminal}
+    :dir: ~
+    :user: dev
+    :host: ubuntu
+
+    sudo snap install zig --classic --channel=latest/beta
+    ```
+
+1. Verify the installation:
+
+    ```{terminal}
+    :dir: ~
+    :user: dev
+    :host: ubuntu
+
+    zig version
+    ```
+
+:::{note}
+The Zig snap does not currently publish a `latest/stable` channel. The `latest/beta` channel tracks the most recent Zig stable releases. The `latest/edge` channel tracks nightly development builds.
+:::
+
+
+## IDE integrations
+
+Several editors and IDEs support Zig, primarily through [ZLS](https://github.com/zigtools/zls) (Zig Language Server), which provides code completion, go-to-definition, error highlighting, and other language features.
+
+[Visual Studio Code](https://code.visualstudio.com/)
+: Install VS Code from the Snap Store, then add the [Zig Language Support](https://marketplace.visualstudio.com/items?itemName=ziglang.vscode-zig) extension from the VS Code Marketplace. The extension automatically installs and manages ZLS.
+
+  Install VS Code with:
+
+  ```{terminal}
+  :dir: ~
+  :user: dev
+  :host: ubuntu
+
+  sudo snap install code --classic
+  ```
+
+[Codium](https://vscodium.com/)
+: The freely-licensed binary distribution of VS Code. Install the [Zig Language Support](https://open-vsx.org/extension/ziglang/vscode-zig) extension from the Open VSX registry.
+
+  Install Codium with:
+
+  ```{terminal}
+  :dir: ~
+  :user: dev
+  :host: ubuntu
+
+  sudo snap install codium --classic
+  ```
+
+:::{note}
+ZLS is managed automatically by the VS Code and Codium extensions. For other editors (Vim, {spellexception}`Neovim`, Emacs, Helix), install ZLS manually. Refer to the [ZLS installation guide](https://github.com/zigtools/zls#installation) for instructions.
+:::
+
+
+## What next
+
+See the tutorial introducing the use of Zig and related tooling: {ref}`use-zig`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Set up Python, Go, Rust, GCC, Clang, .NET, and Java toolchains on Ubuntu Desktop."
+    description: "Set up Python, Go, Rust, GCC, Clang, .NET, Java, and Zig toolchains on Ubuntu Desktop."
 ---
 
 (ubuntu-for-developers)=
@@ -22,7 +22,7 @@ Contribute documentation <howto/contribute-docs.md>
 
 **Ubuntu is a Linux-based operating system that provides a complete development platform supporting multiple programming languages and toolchains.**
 
-**Each supported toolchain integrates with Ubuntu's package management and tooling ecosystem.** Python, Go, Rust, GCC, Clang, .NET, and Java are available through Ubuntu repositories and snaps, together with build tools, debuggers, linters, formatters, and IDEs (integrated development environments).
+**Each supported toolchain integrates with Ubuntu's package management and tooling ecosystem.** Python, Go, Rust, GCC, Clang, .NET, Java, and Zig are available through Ubuntu repositories and snaps, together with build tools, debuggers, linters, formatters, and IDEs (integrated development environments).
 
 **This documentation reduces the time needed to configure a working development environment on Ubuntu.** It covers toolchain installation, first-program tutorials, version-reference data, and background context, providing a path from a fresh Ubuntu Desktop install to a productive development setup.
 
@@ -42,14 +42,14 @@ Setting up development on Ubuntu Desktop involves platform-level choices and too
 
 * **System preparation**: {ref}`Installing Ubuntu Desktop for developers <install-ubuntu>` • {ref}`Using Git version control on Ubuntu <use-git>`
 * **Editor selection**: {ref}`Integrated developer environments <ides>`
-* **Toolchain configuration**: {ref}`Install and set up Python <install-python>` • {ref}`Install and set up Go <install-golang>` • {ref}`Install and set up Rust <install-rust>` • {ref}`Install and set up GCC <install-gcc>` • {ref}`Install and set up Clang <install-clang>` • {ref}`Install and set up .NET <install-dotnet>` • {ref}`Install and set up Java <install-java>`
+* **Toolchain configuration**: {ref}`Install and set up Python <install-python>` • {ref}`Install and set up Go <install-golang>` • {ref}`Install and set up Rust <install-rust>` • {ref}`Install and set up GCC <install-gcc>` • {ref}`Install and set up Clang <install-clang>` • {ref}`Install and set up .NET <install-dotnet>` • {ref}`Install and set up Java <install-java>` • {ref}`Install and set up Zig <install-zig>`
 
 
 ### Active development
 
 These pages cover the toolchain-specific workflows for building, running, and debugging code on Ubuntu Desktop.
 
-* **First programs**: {ref}`Develop with Go <use-go>` • {ref}`Develop with Rust <use-rust>` • {ref}`Develop with GCC <use-gcc>` • {ref}`Develop C and C++ with Clang <use-clang>` • {ref}`Develop with .NET <use-dotnet>` • {ref}`Develop with Java <use-java>`
+* **First programs**: {ref}`Develop with Go <use-go>` • {ref}`Develop with Rust <use-rust>` • {ref}`Develop with GCC <use-gcc>` • {ref}`Develop C and C++ with Clang <use-clang>` • {ref}`Develop with .NET <use-dotnet>` • {ref}`Develop with Java <use-java>` • {ref}`Develop with Zig <use-zig>`
 * **.NET ecosystem**: {ref}`Introduction to the .NET toolchain <dotnet-introduction>` • {ref}`Debugging with .NET <debugging-with-dotnet>`
 * **Java ecosystem**: {ref}`Compile Spring Boot apps to native executables <use-graalvm>` • {ref}`GraalVM native compilation <graalvm-introduction>` • {ref}`Fast start for Spring Boot apps with CRaC <use-crac>`
 
@@ -65,7 +65,7 @@ This section covers distributing software built on Ubuntu Desktop as a Debian pa
 
 Version matrices for each supported toolchain, showing what is available across Ubuntu releases.
 
-* **Toolchain availability**: {ref}`Python <python-toolchain-availability>` • {ref}`Go <go-toolchain-availability>` • {ref}`Rust <rust-toolchain-availability>` • {ref}`GCC <gcc-toolchain-availability>` • {ref}`LLVM/Clang <llvm-toolchain-availability>` • {ref}`.NET <dotnet-toolchain-availability>` • {ref}`Java <java-toolchain-availability>`
+* **Toolchain availability**: {ref}`Python <python-toolchain-availability>` • {ref}`Go <go-toolchain-availability>` • {ref}`Rust <rust-toolchain-availability>` • {ref}`GCC <gcc-toolchain-availability>` • {ref}`LLVM/Clang <llvm-toolchain-availability>` • {ref}`.NET <dotnet-toolchain-availability>` • {ref}`Java <java-toolchain-availability>` • {ref}`Zig <zig-toolchain-availability>`
 
 
 ## How this documentation is organized

--- a/docs/reference/availability/index.md
+++ b/docs/reference/availability/index.md
@@ -19,4 +19,5 @@ GCC <gcc.md>
 .NET <dotnet.md>
 LLVM/Clang <llvm.md>
 Java <java.md>
+Zig <zig.md>
 :::

--- a/docs/reference/availability/zig.md
+++ b/docs/reference/availability/zig.md
@@ -1,0 +1,39 @@
+---
+myst:
+  html_meta:
+    description: "Zig versions available via the Zig snap and Ubuntu packages across Ubuntu releases."
+---
+
+(zig-toolchain-availability)=
+# Available Zig versions
+
+This page lists Zig versions available via the Zig snap and Ubuntu packages.
+
+
+## Ubuntu Zig (deb) packages
+
+Zig packages are available in the Ubuntu archive from Ubuntu 25.10 onward. They are in the `universe` component.
+
+| Ubuntu version | Available Zig versions | {lpsrc}`zig-defaults` version |
+| --- | --- | --- |
+| 26.04 LTS (Resolute Raccoon) | 0.14, 0.15 | 4ubuntu2 |
+| 25.10 (Questing Quokka)      | 0.14        | 4ubuntu1 |
+
+:::{note}
+Zig packages are not available in Ubuntu releases before 25.10 (Questing Quokka). On older releases, install Zig using the snap or download a pre-built binary from [ziglang.org/download](https://ziglang.org/download/).
+:::
+
+| Zig version | Source package |
+|-------------|----------------|
+| 0.15 | {lpsrc}`zig0.15` |
+| 0.14 | {lpsrc}`zig0.14` |
+
+
+## Zig snap
+
+The [`zig` snap](https://snapcraft.io/zig) is a community-maintained package. It does not publish a `latest/stable` channel; the `latest/beta` channel tracks Zig stable releases.
+
+| Zig version | Snap channel |
+|-------------|--------------|
+| 0.17.0-dev  | `latest/edge` |
+| 0.16.0      | `latest/beta` |

--- a/docs/reference/availability/zig.md
+++ b/docs/reference/availability/zig.md
@@ -12,15 +12,15 @@ This page lists Zig versions available via the Zig snap and Ubuntu packages.
 
 ## Ubuntu Zig (deb) packages
 
-Zig packages are available in the Ubuntu archive from Ubuntu 25.10 onward. They are in the `universe` component.
+Zig packages are available in the Ubuntu archive from Ubuntu 25.10 onward. They are in the `universe` component and only available for the `amd64`, `arm64`, and (starting with {pkg}`zig0.15`) `riscv64` architectures.
 
 | Ubuntu version | Available Zig versions | {lpsrc}`zig-defaults` version |
 | --- | --- | --- |
-| 26.04 LTS (Resolute Raccoon) | 0.14, 0.15 | 4ubuntu2 |
-| 25.10 (Questing Quokka)      | 0.14        | 4ubuntu1 |
+| 26.04 LTS (Resolute Raccoon) | 0.14 | 4ubuntu2 |
+| 25.10 (Questing Quokka)      | 0.14 | 4ubuntu1 |
 
-:::{note}
-Zig packages are not available in Ubuntu releases before 25.10 (Questing Quokka). On older releases, install Zig using the snap or download a pre-built binary from [ziglang.org/download](https://ziglang.org/download/).
+:::{admonition} Zig 0.15 in Ubuntu 26.04 LTS (Resolute Raccoon)
+Zig 0.15 is available in Resolute as the {pkg}`zig0.15` package, but the {lpsrc}`zig-defaults` source package points to {pkg}`zig0.14`.
 :::
 
 | Zig version | Source package |
@@ -28,6 +28,9 @@ Zig packages are not available in Ubuntu releases before 25.10 (Questing Quokka)
 | 0.15 | {lpsrc}`zig0.15` |
 | 0.14 | {lpsrc}`zig0.14` |
 
+:::{note}
+Zig packages are not available in Ubuntu releases before 25.10 (Questing Quokka). On older releases, install Zig using the snap or download a pre-built binary from [ziglang.org/download](https://ziglang.org/download/).
+:::
 
 ## Zig snap
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -23,6 +23,7 @@ Develop with GCC <gcc-use>
 Develop with Clang <clang-use>
 Develop with .NET <dotnet-use>
 Develop with Java <java-use>
+Develop with Zig <zig-use>
 Native compile with GraalVM <graalvm-use>
 Checkpoint/Restore with OpenJDK CRaC <crac-use>
 :::

--- a/docs/tutorials/zig-use.md
+++ b/docs/tutorials/zig-use.md
@@ -1,0 +1,348 @@
+---
+myst:
+  html_meta:
+    description: "Build, run, and test Zig programs on Ubuntu using zig build and zig build-exe."
+---
+
+(use-zig)=
+# Develop with Zig on Ubuntu
+
+This tutorial shows how to create, build, run, and test a Zig program on Ubuntu. For instructions on how to install Zig and set up editor tooling, see the dedicated guide on {ref}`install-zig`. This article assumes that tooling suggested in that article has been installed.
+
+
+## Creating a Zig project
+
+1. Create a project directory and change into it:
+
+    ```{terminal}
+    :dir: ~
+    :user: dev
+    :host: ubuntu
+
+    mkdir -p ~/zig/hello && cd ~/zig/hello
+    ```
+
+1. Initialize the project:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    zig init
+    ```
+
+   {command}`zig init` creates the following project structure:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    tree
+
+    .
+    ├── build.zig
+    ├── build.zig.zon
+    └── src
+        ├── main.zig
+        └── root.zig
+    ```
+
+   * {file}`build.zig` - the build script, written in Zig itself
+   * {file}`build.zig.zon` - package manifest (name, version, dependencies)
+   * {file}`src/main.zig` - the executable entry point
+   * {file}`src/root.zig` - a library module stub
+
+1. Inspect the generated {file}`src/main.zig`:
+
+    ```{code-block} zig
+    :caption: `src/main.zig`
+
+    const std = @import("std");
+
+    pub fn main() !void {
+        std.debug.print("All your {s} are belong to us.\n", .{"codebase"});
+    }
+    ```
+
+   :::{note}
+   {command}`zig init` generates the {file}`main.zig` file with copious comments, as well as other logic, including example tests and an import of the `hello_lib` library that was also created; above is just the bare minimum needed for the example program.
+
+   The project would still compile and run if you stripped all the extra code and only left what we're showing here.
+   :::
+
+
+## Building and running
+
+1. Build and run the project using {command}`zig build run`:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    zig build run
+
+    All your codebase are belong to us.
+    ```
+
+1. Replace the message in {file}`src/main.zig` with 'Hello, world!':
+
+    ```{code-block} zig
+    :caption: `src/main.zig`
+
+    const std = @import("std");
+
+    pub fn main() !void {
+        std.debug.print("Hello, world!\n", .{});
+    }
+    ```
+
+1. Build and run again:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    zig build run
+
+    Hello, world!
+    ```
+
+
+## Compiling a single file
+
+Use {command}`zig build-exe` to compile a single source file without a project structure.
+
+1. Create a standalone source file:
+
+    ```{code-block} zig
+    :caption: `hello.zig`
+
+    const std = @import("std");
+
+    pub fn main() !void {
+        std.debug.print("Hello, world!\n", .{});
+    }
+    ```
+
+1. Compile it:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    zig build-exe hello.zig
+    ```
+
+   This produces an executable named {file}`hello` in the current directory.
+
+1. Run the executable:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    ./hello
+
+    Hello, world!
+    ```
+
+
+## Testing Zig code
+
+Zig has a built-in test runner. Test blocks are declared with the `test` keyword and use the `std.testing` namespace for assertions.
+
+The generated {file}`src/root.zig` already contains an example test.
+
+1. Review the {file}`src/root.zig` example test:
+
+    ```{code-block} zig
+    :caption: `src/root.zig`
+
+    const std = @import("std");
+    const testing = std.testing;
+
+    pub export fn add(a: i32, b: i32) i32 {
+        return a + b;
+    }
+
+    test "basic add functionality" {
+        try testing.expect(add(3, 7) == 10);
+    }
+    ```
+
+1. Run the test:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    zig build --summary all test
+    ```
+
+    :::{raw} html
+    <div class="highlight-default notranslate"><div class="highlight"><pre><span style="color:#18b2b2;">Build Summary:</span><span style="color:#b2b2b2;"> 5/5 steps succeeded; 1/1 tests passed</span><span style="color:#b2b2b2;">
+    </span><span style="color:#b2b2b2;">test</span><span style="color:#18b218;"> success</span><span style="color:#b2b2b2;">
+    </span><span style="color:#b2b2b2;">├─ run test</span><span style="color:#18b218;"> 1 passed</span><span style="color:#656565;"> 635us MaxRSS:1M</span><span style="color:#b2b2b2;">
+    </span><span style="color:#b2b2b2;">│ &#160;└─ zig test Debug native</span><span style="color:#18b218;"> success</span><span style="color:#656565;"> 1s MaxRSS:260M</span><span style="color:#b2b2b2;">
+    </span><span style="color:#b2b2b2;">└─ run test</span><span style="color:#18b218;"> success</span><span style="color:#656565;"> 191us MaxRSS:1M</span><span style="color:#b2b2b2;">
+    </span><span style="color:#b2b2b2;"> &#160;&#160;└─ zig test Debug native</span><span style="color:#18b218;"> success</span><span style="color:#656565;"> 1s MaxRSS:261M</span></pre></div></div>
+    :::
+
+
+### Testing STDOUT output
+
+To test the actual "Hello, world!" function of the program, you can use a special feature of Zig: duck-typing at compile time. In this example, we create a `hello()` function that accepts any object that provides a `.print()` method.
+
+This separates the output destination of the function from its logic, which makes it testable. In this way, the function can write to STDOUT, and the test is able to capture the output by directing it somewhere else where it can check it.
+
+Modify the {file}`src/main.zig` file:
+
+```{code-block} zig
+:caption: `src/main.zig`
+
+const std = @import("std");
+
+// Duck-typing the 'writer' parameter
+pub fn hello(writer: anytype) !void {
+    try writer.print("Hello, world!\n", .{});
+}
+
+// Sending output to STDOUT
+pub fn main() !void {
+    try hello(std.io.getStdOut().writer());
+}
+
+// Sending output to an array
+test "hello writes 'Hello, world!' to stdout" {
+    var output = std.ArrayList(u8).init(std.testing.allocator);
+    defer output.deinit();
+    try hello(output.writer());
+    try std.testing.expectEqualStrings("Hello, world!\n", output.items);
+}
+```
+
+:::{note}
+`defer` ensures that `output.deinit()` (which frees the allocated memory) is called automatically when the test ends (regardless of whether the function succeeds or not).
+:::
+
+
+## Cross-compiling with `zig cc`
+
+Zig includes a built-in C (Clang LLVM) compiler, `zig cc`, which works as a drop-in replacement for C compilers with first-class cross-compilation support. No separate cross-toolchain installation is required.
+
+
+### Compiling C code natively
+
+1. Create a C source file:
+
+    ```{code-block} c
+    :caption: `hello.c`
+
+    #include <stdio.h>
+
+    int main(void) {
+        printf("Hello, world!\n");
+        return 0;
+    }
+    ```
+
+1. Compile and run:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    zig cc hello.c -o hello && ./hello
+
+    Hello, world!
+    ```
+
+
+### Compiling for other architectures
+
+The `zig cc` command compiles for any supported target without additional toolchain packages.
+
+1. Cross-compile for 64-bit ARM Linux (statically linked against the [musl](https://musl.libc.org/) libc implementation):
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    zig cc hello.c -target aarch64-linux-musl -o hello-arm64
+    ```
+
+1. Verify the binary targets ARM64:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    file hello-arm64
+
+    hello-arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV),
+                 statically linked, not stripped
+    ```
+
+1. Install QEMU user-mode emulation. Ubuntu's `qemu-user-binfmt` package registers `binfmt_misc` handlers automatically, so foreign-architecture binaries run transparently:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    sudo apt install qemu-user-binfmt
+    ```
+
+   Ubuntu's {pkg}`qemu-user-binfmt` package registers `binfmt_misc` handlers automatically, so foreign-architecture binaries run transparently.
+
+1. Run the Aarch64 executable:
+
+    ```{terminal}
+    :dir: ~/zig/hello
+    :user: dev
+    :host: ubuntu
+
+    ./hello-arm64
+
+    Hello, world!
+    ```
+
+:::{note}
+Similarly, cross-compile for 64-bit Windows and run with [Wine](https://www.winehq.org/):
+
+```{terminal}
+:dir: ~/zig/hello
+:user: dev
+:host: ubuntu
+
+zig cc hello.c -target x86_64-windows-gnu -o hello.exe
+```
+
+```{terminal}
+:dir: ~/zig/hello
+:user: dev
+:host: ubuntu
+
+sudo apt install wine
+```
+
+```{terminal}
+:dir: ~/zig/hello
+:user: dev
+:host: ubuntu
+
+wine hello.exe
+
+Hello, world!
+```
+:::

--- a/docs/tutorials/zig-use.md
+++ b/docs/tutorials/zig-use.md
@@ -293,7 +293,7 @@ The `zig cc` command compiles for any supported target without additional toolch
                  statically linked, not stripped
     ```
 
-1. Install QEMU user-mode emulation. Ubuntu's `qemu-user-binfmt` package registers `binfmt_misc` handlers automatically, so foreign-architecture binaries run transparently:
+1. Install QEMU user-mode emulation:
 
     ```{terminal}
     :dir: ~/zig/hello


### PR DESCRIPTION
@pushkarnk, I'd appreciate your review on this.

Notes:

- For installation and availability reference, I included the non-Canonical snap as well -- with plenty of warning that it's community-maintained. But if you think it's not a good idea, I'll remove it.


- For the 'hello world' tutorial, I wanted to add something that's at least a bit Zig-specific. So, I mentioned:


  - `zig cc` and compiling C code + cross-compilation. I'd welcome advice on other/better features to highlight.


  - For testing, I added a test to check the 'hello world' output. I'm new to Zig, but I thought the `anytype` duck-typing was an interesting feature, so I built it around it. And after scouring the Zig docs and the web, I decided to use `ArrayList` to store the output. But when I asked AI for review, it wanted me to use `fixedBufferStream` instead -- that looked OK, but I then realized I couldn't find it in the lang. reference in 0.15+. Which led me to find out that it was deprecated, and the whole IO thing redesigned. So, I went back to `ArrayList`. Please, let me know if it makes sense.

cc @edibotopic 