### PR TITLE
Feat/update llvm availability matrix

### DIFF
--- a/docs/reference/availability/llvm.md
+++ b/docs/reference/availability/llvm.md
@@ -13,23 +13,24 @@ This page lists LLVM/Clang versions available in Ubuntu releases.
 
 | Ubuntu version              | available LLVM/Clang versions | {lpsrc}`llvm-defaults` |
 | --- | --- | --- |
-| 26.04 LTS (Resolute Raccoon) | 17, 18, 19, 20, 21 | 21 |    
-| 25.10 (Questing Quokka)     | 14, 15, 17, **18**, **19**, **20**, 21 | 20 |
-| 25.04 (Plucky Puffin)       | 14, 15, 17, **18**, **19**, **20** | 20 |
-| 24.10 (Oracular Oriole)     | 14, 15, 16, 17, **18**, **19** | 19 |
-| 24.04 LTS (Noble Numbat)    | 14, 15, 16, **17**, **18**, 19 | 18 |
-| 22.04 LTS (Jammy Jellyfish) | 11, 12, **13**, **14**, **15** | 14 |
-| 20.04 LTS (Focal Fossa)     | 6, 7, 8, **9**, **10**, **11**, **12**, 18 | 10 |
-| 18.04 LTS (Bionic Beaver)   | 3.7, **3.9**, 4, 5, **6**, **7**, **8**, **9**, **10** | 6 |
-| 16.04 LTS (Xenial Xerus)    | **3.6**, 3.7, **3.8**, 3.9, **4**, **5**, **6**, 8 | 3.8 |
-| 14.04 LTS (Trusty Tahr)     | 3.3, **3.4**, 3.5, **3.6**, **3.8**, 3.9 | 3.4 |
+| 26.10 (Stonking Stingray)¹    | 17, 18, 19, 20, **21**, 22 | 21 |   
+| 26.04 LTS (Resolute Raccoon) | 17, 18, 19, 20, **21**, 22 | 21 |   
+| 25.10 (Questing Quokka)      | 14, 15, 17, **18**, **19**, **20**, 21 | 20 |
+| 24.04 LTS (Noble Numbat)     | 14, 15, 16, **17**, **18**, 19, 20 | 18 |
+| 22.04 LTS (Jammy Jellyfish)  | 11, 12, **13**, **14**, **15** | 14 |
+| 20.04 LTS (Focal Fossa)      | 6, 7, 8, **9**, **10**, **11**, **12**, 18 | 10 |
+| 18.04 LTS (Bionic Beaver)    | 3.7, **3.9**, 4, 5, **6**, **7**, **8**, **9**, **10** | 6 |
+| 16.04 LTS (Xenial Xerus)     | **3.6**, 3.7, **3.8**, 3.9, **4**, **5**, **6**, 8 | 3.8 |
+| 14.04 LTS (Trusty Tahr)      | 3.3, **3.4**, 3.5, **3.6**, **3.8**, 3.9 | 3.4 |
 
 <!-- Do not forget to add 4 spaces at the end of line to keep future diffs more readable -->
 **bold** -- package is in main    
+¹ not yet released, still in active development
 
 | LLVM Version | Source package | 
 |--------------|----------------|
 | (close to the latest upstream snapshot) | {lpsrc}`llvm-toolchain-snapshot` | 
+| 22 | {lpsrc}`llvm-toolchain-22` |
 | 21 | {lpsrc}`llvm-toolchain-21` |
 | 20 | {lpsrc}`llvm-toolchain-20` |
 | 19 | {lpsrc}`llvm-toolchain-19` |

--- a/docs/reference/availability/llvm.md
+++ b/docs/reference/availability/llvm.md
@@ -13,7 +13,7 @@ This page lists LLVM/Clang versions available in Ubuntu releases.
 
 | Ubuntu version              | available LLVM/Clang versions | {lpsrc}`llvm-defaults` |
 | --- | --- | --- |
-| 26.10 (Stonking Stingray)¹    | 17, 18, 19, 20, **21**, 22 | 21 |   
+| 26.10 (Stonking Stingray)¹   | 17, 18, 19, 20, **21**, 22 | 21 |   
 | 26.04 LTS (Resolute Raccoon) | 17, 18, 19, 20, **21**, 22 | 21 |   
 | 25.10 (Questing Quokka)      | 14, 15, 17, **18**, **19**, **20**, 21 | 20 |
 | 24.04 LTS (Noble Numbat)     | 14, 15, 16, **17**, **18**, 19, 20 | 18 |


### PR DESCRIPTION
I also removed plucky and oracular which are EoL and adjusted the markdown formatting for the '|' after the Ubuntu release name.