### PR TITLE
chores: Update rust version table

### DIFF
--- a/docs/reference/availability/rust.md
+++ b/docs/reference/availability/rust.md
@@ -26,11 +26,10 @@ See the [user guide for rustup](https://rust-lang.github.io/rustup/concepts/chan
 | Ubuntu version | available Rust versions | {lpsrc}`rust-defaults` version | 
 | --- | --- | --- |
 | 26.04 LTS (Resolute Raccoon)| 1.91, 1.92, **1.93** | 1.93 |
-| 25.10 (Questing Quokka)     | **1.85**, 1.88 | 1.85 |
-| 25.04 (Plucky Puffin)       | 1.81, 1.82, 1.83, **1.84** | 1.84 |
-| 24.04 LTS (Noble Numbat)    | 1.74, **1.75**, 1.76, 1.77, 1.78, 1.79, 1.80, 1.81, 1.82 | - |
-| 22.04 LTS (Jammy Jellyfish) | 1.62, **1.75**, 1.76, 1.77, 1.78, 1.79, 1.80, 1.81, 1.82 | - |
-| 20.04 LTS (Focal Fossa)     | 1.75, 1.76, 1.77, 1.78, 1.79, 1.80, 1.82 | - |
+| 25.10 (Questing Quokka)     | **1.85**, 1.88, 1.91 | 1.85 |
+| 24.04 LTS (Noble Numbat)    | 1.74, **1.75**, 1.76, 1.77, 1.78, 1.79, 1.80, 1.81, 1.82, 1.83, 1.84, 1.85, 1.89, 1.91 | - |
+| 22.04 LTS (Jammy Jellyfish) | 1.62, **1.75**, 1.76, 1.77, 1.78, 1.79, 1.80, 1.81, 1.82, 1.83, 1.84, 1.85, 1.89, 1.91 | - |
+| 20.04 LTS (Focal Fossa)     | 1.75, 1.76, 1.77, 1.78, 1.79, 1.80 | - |
 | 18.04 LTS (Bionic Beaver)   | 1.75 | - |
 | 16.04 LTS (Xenial Xerus)    | 1.75 | - |
 | 14.04 LTS (Trusty Tahr)     | 1.75 | - |
@@ -54,7 +53,7 @@ See the [user guide for rustup](https://rust-lang.github.io/rustup/concepts/chan
 | 1.78 | {lpsrc}`rustc-1.78` |
 | 1.77 | {lpsrc}`rustc-1.77` |
 | 1.76 | {lpsrc}`rustc-1.76` |
-| 1.75 | {lpsrc}`rustc-1.75` |
+| 1.75 | {lpsrc}`rustc` |
 | 1.74 | {lpsrc}`rustc-1.74` |
 | 1.62 | {lpsrc}`rustc-1.62` |
 


### PR DESCRIPTION
An update of the rust version table with data from rmadison. I also removed plucky since it is eol.

Tagging @maxgmr since I am not from the rust toolchain team.

Note: The link to rustc-1.75 on that page (https://launchpad.net/ubuntu/+source/rustc-1.75) is not very helpful, since this version was mostly published under https://launchpad.net/ubuntu/+source/rustc. Should we do something about this (we could either link to the binary packages or to the `rustc` package)?